### PR TITLE
Fixes for export NetCDF files by Delft-FEWS

### DIFF
--- a/packages/src/cf_timeseries.cpp
+++ b/packages/src/cf_timeseries.cpp
@@ -34,6 +34,8 @@
 
 #include "cf_time_series.h"
 #include "netcdf.h"
+#include<boost/algorithm/string/split.hpp>       
+#include<boost/algorithm/string.hpp>
 
 using namespace std;
 
@@ -186,6 +188,14 @@ void TSFILE::read_times(QProgressBar * pgBar, long pgBar_start, long pgBar_end)
                     // retrieve the long_name, standard_name -> var_name for the xaxis label
                     length = (size_t) -1;
                     status = nc_inq_var(this->m_ncid, i_var, var_name, NULL, &ndims, &dimids, &natts);
+                    
+                    // skip variable where name contains analysis_time
+                    string var_name_str(var_name);
+                    string var_sub_str("analysis_time");
+                    if (var_name_str.find(var_sub_str) != string::npos) {
+                        continue;
+                    }
+                    
                     status = nc_inq_attlen(this->m_ncid, i_var, "long_name", &length);
                     if (status == NC_NOERR)
                     {
@@ -399,6 +409,14 @@ void TSFILE::read_parameters()
             coord = (char *)malloc(sizeof(char) * (length + 1));
             status = nc_get_att(this->m_ncid, i_var, "coordinates", coord);
             coord[length] = '\0';
+            
+            // if coordinates contains multiple elements, ignore it then
+            vector<string> strVec;
+            using boost::is_any_of;
+            boost::algorithm::split(strVec, string(coord), is_any_of(" "),boost::token_compress_on);
+            if (strVec.size() > 1) {
+                status = nc_inq_attlen(this->m_ncid, i_var, "babaslfalskjlskdjflksdjf", &length);
+            }
         }
 
         if (status != NC_NOERR)


### PR DESCRIPTION
@mooiman Ik gebruik de PlotCFTS tool veel voor D-HYDRO resultaten, maar eerder ook af en toe voor NetCDF die Delft-FEWS exporteert. Helaas zag ik dat het niet meer werkte en in mijn vrije tijd heb ik uitgezocht waarom en een paar fixes in de code doorgevoerd. Succesvol getest met zowel D-HYDRO his.nc bestand als met een FEWS nc bestand. Zie maar wat je hier mee doet. Momenteel gebruik ik namelijk mijn aangepaste versie.